### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         files: 'module.json'
       env:
         version: ${{github.event.release.tag_name}}
-        manifest: https://raw.githubusercontent.com/VanceCole/roofs/master/module.json
+        manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
         download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
 
     # create a zip file with all files required by the module to add to the release

--- a/module.json
+++ b/module.json
@@ -27,6 +27,6 @@
   ],
   "url": "https://github.com/League-of-Foundry-Developers/roofs",
   "manifest": "https://github.com/League-of-Foundry-Developers/roofs/releases/latest/download/module.json",
-  "download": "https://github.com/League-of-Foundry-Developers/roofs/releases/download/0.2.0/module.zip",
+  "download": "https://github.com/League-of-Foundry-Developers/roofs/releases/latest/download/module.zip",
   "changelog": "https://github.com/League-of-Foundry-Developers/roofs/blob/master/changelog.md"
 }

--- a/module.json
+++ b/module.json
@@ -26,7 +26,7 @@
     }
   ],
   "url": "https://github.com/League-of-Foundry-Developers/roofs",
-  "manifest": "https://raw.githubusercontent.com/League-of-Foundry-Developers/roofs/master/module.json",
+  "manifest": "https://github.com/League-of-Foundry-Developers/roofs/releases/latest/download/module.json",
   "download": "https://github.com/League-of-Foundry-Developers/roofs/releases/download/0.2.0/module.zip",
   "changelog": "https://github.com/League-of-Foundry-Developers/roofs/blob/master/changelog.md"
 }


### PR DESCRIPTION
fix build action to stop releases from looking at the original repo for updates
set master manifest to use the latest release always

this will make it so that you basically don't have to worry about the master manifest