### PR TITLE
Add support for webm in roof tiles.

### DIFF
--- a/scripts/RoofsLayer.js
+++ b/scripts/RoofsLayer.js
@@ -58,7 +58,14 @@ export default class RoofsLayer extends CanvasLayer {
     log(`Creating roof ${tile.data._id}`);
     const container = new PIXI.Container();
     const wrapper = new PIXI.Container();
-    const sprite = PIXI.Sprite.from(tile.data.img);
+    const texture;
+    if (/.*\.webm/.test(tile.data.img)) {
+      texture = PIXI.Texture.fromVideo(tile.data.img);
+      texture.baseTexture.resource.source.loop = true;
+    } else {
+      texture = PIXI.Texture.from(tile.data.img);
+    }
+    const sprite = PIXI.Sprite.from(texture);
     wrapper.addChild(sprite);
     container.addChild(wrapper);
     tile.roof = { container, wrapper, sprite };

--- a/scripts/RoofsLayer.js
+++ b/scripts/RoofsLayer.js
@@ -58,12 +58,11 @@ export default class RoofsLayer extends CanvasLayer {
     log(`Creating roof ${tile.data._id}`);
     const container = new PIXI.Container();
     const wrapper = new PIXI.Container();
-    const texture;
     if (/.*\.webm/.test(tile.data.img)) {
-      texture = PIXI.Texture.fromVideo(tile.data.img);
+      var texture = PIXI.Texture.fromVideo(tile.data.img);
       texture.baseTexture.resource.source.loop = true;
     } else {
-      texture = PIXI.Texture.from(tile.data.img);
+      var texture = PIXI.Texture.from(tile.data.img);
     }
     const sprite = PIXI.Sprite.from(texture);
     wrapper.addChild(sprite);


### PR DESCRIPTION
Webm files are useful for potential graphical design choices like swaying trees that serve as roofs or a burning roof. Adding in this support allows for more creative flexibility and new styles of scene design.